### PR TITLE
Local_manifests: fix sync error

### DIFF
--- a/local_manifest.xml
+++ b/local_manifest.xml
@@ -75,7 +75,6 @@
             remote="LOS" />
 
        <!--devicesettings-->
-    <remove-project name="LineageOS/android_packages_resources_devicesettings" />
     <project path="packages/resources/devicesettings" name="packages_resources_devicesettings" remote="hsx02" revision="lineage-18.1" />
      
 </manifest>


### PR DESCRIPTION
fatal: remove-project element specifies non-existent project: LineageOS/android_packages_resources_devicesettings
+ true